### PR TITLE
Add npm publish github action

### DIFF
--- a/.github/workflows/npmpublish.yml
+++ b/.github/workflows/npmpublish.yml
@@ -1,0 +1,22 @@
+name: Node.js Package
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  publish-npm:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12
+          registry-url: https://registry.npmjs.org/
+      - run: npm install --no-save yarn
+      - run: yarn install --frozen-lockfile
+      - run: yarn build
+      - run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
-  "name": "lilac",
+  "name": "@codear/lilac",
   "description": "Components library",
-  "version": "0.0.1",
+  "version": "0.0.2",
+  "files": ["dist"],
   "repository": "WebConfTech/lilac",
   "author": "WebConf <hola@webconf.tech>",
   "license": "MIT",


### PR DESCRIPTION
Initial implementation of the npm publish action.
Had to change the package version to `0.0.2` because I used `0.0.1` while testing (didn't realize it wouldn't be reusable afterwards).